### PR TITLE
Fixed extractors and changed keycard fix

### DIFF
--- a/QualityImprover/Mod.cs
+++ b/QualityImprover/Mod.cs
@@ -4,6 +4,11 @@ namespace QualityImprover
     public class Mod : PulsarMod
     {
         public override string Version => "2.3.6";
+        public Mod()
+        {
+            Instance = this;
+        }
+        internal static Mod Instance;
 
         public override string Author => "pokegustavo, OnHyex";
 

--- a/QualityImprover/Mod.cs
+++ b/QualityImprover/Mod.cs
@@ -1,14 +1,17 @@
 ﻿using PulsarModLoader;
+using QualityImprover.Patches;
 namespace QualityImprover
 {
     public class Mod : PulsarMod
     {
-        public override string Version => "2.3.6";
         public Mod()
         {
             Instance = this;
+            //Add Version check for host having the extractor fixes to disable some client side changes
+            Events.Instance.ClientModlistRecievedEvent += QualityImprover.Patches.ExtractorFixes.ExtractorFixesHostVersionCheck;
         }
         internal static Mod Instance;
+        public override string Version => "2.3.7";
 
         public override string Author => "pokegustavo, OnHyex";
 
@@ -19,6 +22,14 @@ namespace QualityImprover
         public override string HarmonyIdentifier()
         {
             return "pokegustavo.qualityimprover";
+        }
+        public override void Unload()
+        {
+            base.Unload();
+            //Removing the version check for host having extractor fixes on unload
+            Events.Instance.ClientModlistRecievedEvent -= QualityImprover.Patches.ExtractorFixes.ExtractorFixesHostVersionCheck;
+            //Deletes the fix host button on the current playership when unloaded
+            ExtractorFixes.FixExtractorForPlayerShipUpdating.DeleteButtonOnUnload();
         }
     }
 }

--- a/QualityImprover/Patches.cs
+++ b/QualityImprover/Patches.cs
@@ -10,7 +10,7 @@ using static PulsarModLoader.Patches.HarmonyHelpers;
 
 namespace QualityImprover
 {
-    public class Patches
+    namespace Patches
     {
         [HarmonyPatch(typeof(PLShipInfoBase), "UpdateVirusSendQueue")]
         class BetterVirusTargeting

--- a/QualityImprover/Patches.cs
+++ b/QualityImprover/Patches.cs
@@ -1350,7 +1350,7 @@ namespace QualityImprover
             [HarmonyPatch(typeof(PLShipInfo), "<CreateSalvageOpUIs>b__360_1")]
             class ExtractScreenFixesGoRight
             {
-                //Disables the go right button on the extractor screen 
+                //Disables the go right button on the extractor screen when the host doesn't have the mod and they aren't on board to prevent desync
                 static bool Prefix(PLShipInfo __instance, int ___SalvageComp_ID, List<PLShipComponent> ___m_CachedSalvageableComponents)
                 {
                     if (!(MasterClientHasUpdatedMod || IsHostOnBoard()))
@@ -1372,6 +1372,7 @@ namespace QualityImprover
             [HarmonyPatch(typeof(PLShipInfo), "<CreateSalvageOpUIs>b__360_2")]
             class ExtractScreenFixesGoLeft
             {
+                //Disables the go left button on the extractor screen when the host doesn't have the mod and they aren't on board to prevent desync
                 static bool Prefix(PLShipInfo __instance, int ___SalvageComp_ID, List<PLShipComponent> ___m_CachedSalvageableComponents)
                 {
                     if (!(MasterClientHasUpdatedMod || IsHostOnBoard()))

--- a/QualityImprover/Patches.cs
+++ b/QualityImprover/Patches.cs
@@ -1262,7 +1262,7 @@ namespace QualityImprover
                             for (int i = salvageCompIndex; i < 0; i++)
                             {
                                 instance.photonView.RPC("SalvageNext", PhotonTargets.MasterClient, new object[0]);
-                                await Task.Delay(200);
+                                await Task.Delay(100);
                             }
                         }
                         if (salvageCompIndex > salvageableComponentsCount)

--- a/QualityImprover/Patches.cs
+++ b/QualityImprover/Patches.cs
@@ -1,9 +1,13 @@
 ﻿using CodeStage.AntiCheat.ObscuredTypes;
 using HarmonyLib;
+using PulsarModLoader.MPModChecks;
+using PulsarModLoader.Patches;
+using PulsarModLoader.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
 using static PulsarModLoader.Patches.HarmonyHelpers;
@@ -1110,5 +1114,338 @@ namespace QualityImprover
                 return PLServer.Instance != null && PLServer.Instance.IsReflection_FlipIsActiveLocal && PLInput.Instance.GetButton(PLInputBase.EInputActionName.maneuver_mode_hold) ? -1 : 1;
             }
         }
+        
+        class ExtractorFixes
+        {
+            public static int HostSalvageID = 0;
+            public static Task AsyncNonHostSyncer = null;
+            internal static bool MasterClientHasUpdatedMod = false;
+            [HarmonyPatch(typeof(PLShipInfo), "UpdateSalvageUI")]
+            internal class FixExtractorForPlayerShipUpdating
+            {
+                static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+                {
+                    List<CodeInstruction> instructionslist = instructions.ToList();
+                    //Switches extractor screen updating to run if it is the playership or local player is on board to keep everything running on the playership all the time
+                    //And have the screens look right on other unclaimed ships
+                    CodeInstruction[] targetSequence = new CodeInstruction[]
+                    {
+                        new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(PLShipInfo), "LocalPlayerOnboard")),
+                    };
+                    CodeInstruction[] ReplacementSequence = new CodeInstruction[]
+                    {
+                        new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(FixExtractorForPlayerShipUpdating), "PatchMethod1")),
+                    };
+                    instructionslist = HarmonyHelpers.PatchBySequence(instructions, targetSequence, ReplacementSequence, PatchMode.REPLACE, CheckMode.NONNULL, false).ToList();
+                    //Patches the condition of an if statement to be something else so that it can hide the extractor screen when the host is out of sync if the host doesn't have the mod and instead display the fix host sync button
+                    targetSequence = new CodeInstruction[]
+                    {
+                        new CodeInstruction(OpCodes.Ldarg_0, null),//kept
+                        new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(PLShipInfo), "SalvageComp_ID")),//removed
+                        new CodeInstruction(OpCodes.Ldc_I4_M1, null),//kept
+                        new CodeInstruction(OpCodes.Beq, null)//kept
+                    };
+                    ReplacementSequence = new CodeInstruction[]
+                    {
+                        //new CodeInstruction(OpCodes.Ldarg_0, null), not removed from target sequence just reused
+                        new CodeInstruction(OpCodes.Dup, null),
+                        new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(PLShipInfo), "SalvageComp_ID")),
+                        new CodeInstruction(OpCodes.Ldarg_0),
+                        new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(PLShipInfo), "m_CachedSalvageableComponents")),
+                        new CodeInstruction(OpCodes.Ldarg_0),
+                        new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(PLShipInfo), "SalvageUIRoot")),
+                        new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(FixExtractorForPlayerShipUpdating), "PatchMethod2"))
+                    };
+                    int index = HarmonyHelpers.FindSequence(instructions, targetSequence, CheckMode.NONNULL, false);
+                    if (index != -1)
+                    {
+                        index = index - targetSequence.Length;
+                        instructionslist.RemoveRange(index + 1, targetSequence.Length - 3);
+                        instructionslist.InsertRange(index + 1, ReplacementSequence);
+                    }
+                    else
+                    {
+                        Debug.Log("Failed to find Sequence for extrator client side syncing fix");
+                    }
+                    return instructionslist;
+                }
+                //replacement method for running if the ship is the playership or has local player onboard
+                static bool PatchMethod1(PLShipInfo instance)
+                {
+                    return PLEncounterManager.Instance.PlayerShip == instance || instance.LocalPlayerOnboard();
+                }
+                static int PatchMethod2(PLShipInfo instance, int salvageCompID, List<PLShipComponent> extractableComponents, GameObject salvageUIRoot)
+                {
+                    if (PLEncounterManager.Instance.PlayerShip != instance)
+                    {
+                        return -1;
+                    }
+                    if (MasterClientHasUpdatedMod)
+                    {
+                        return salvageCompID;
+                    }
+                    //Creates a new button if the new playership doesn't have the fix host button already
+                    if (instance != storedCurrentShip)
+                    {
+                        storedCurrentShip = instance;
+                        //tries to find currently existing fix host button
+                        Transform temp = salvageUIRoot.transform.Find("SyncBtn");
+                        //Creates new fix host button
+                        if (temp == null)
+                        {
+                            syncButton = new GameObject("SyncBtn", new Type[]
+                            {
+                                typeof(Image),
+                                typeof(Button)
+                            });
+                            Button component = syncButton.GetComponent<Button>();
+                            Image image = syncButton.GetComponent<Image>();
+                            image.sprite = PLGlobal.Instance.TabFillSprite;
+                            image.type = Image.Type.Sliced;
+                            image.transform.SetParent(salvageUIRoot.transform);
+                            component.transform.localPosition = Vector3.zero;
+                            component.transform.localRotation = Quaternion.identity;
+                            component.transform.localScale = Vector3.one;
+                            component.gameObject.layer = 3;
+                            component.GetComponent<RectTransform>().anchoredPosition3D = component.transform.localPosition;
+                            component.GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 250f);
+                            component.GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 50f);
+                            ColorBlock colors = component.colors;
+                            colors.normalColor = Color.gray;
+                            component.colors = colors;
+                            component.onClick.AddListener(delegate
+                            {
+                                //Code to run the syncing method
+                                if (AsyncNonHostSyncer == null || AsyncNonHostSyncer.IsCompleted)
+                                {
+                                    Messaging.Notification("Ran Client Side Sync");
+                                    int i = HostSalvageID;
+                                    int count = extractableComponents.Count;
+                                    AsyncNonHostSyncer = NonModdedHostSynctoClient(instance, i, count);
+                                }
+                            });
+                            GameObject gameObject = new GameObject("SyncBtnLabel", new Type[] { typeof(Text) });
+                            gameObject.transform.SetParent(syncButton.transform);
+                            gameObject.transform.localPosition = Vector3.zero;
+                            gameObject.transform.localRotation = Quaternion.identity;
+                            gameObject.transform.localScale = Vector3.one;
+                            Text component2 = gameObject.GetComponent<Text>();
+                            component2.alignment = TextAnchor.MiddleCenter;
+                            component2.resizeTextForBestFit = true;
+                            component2.resizeTextMinSize = 8;
+                            component2.resizeTextMaxSize = 18;
+                            component2.color = Color.black;
+                            component2.raycastTarget = false;
+                            component2.text = "Fix Host Extractor";
+                            component2.font = PLGlobal.Instance.MainFont;
+                            component2.GetComponent<RectTransform>().anchoredPosition3D = component2.transform.localPosition;
+                            component2.GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 200f);
+                            component2.GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 50f);
+                        }
+                        else
+                        {
+                            syncButton = temp.gameObject;
+                        }
+                    }
+                    bool flag = HostSalvageID < 0 || HostSalvageID > extractableComponents.Count;
+                    PLGlobal.SafeGameObjectSetActive(syncButton, flag);
+                    return flag ? -1 : 0;
+                }
+                private static async Task NonModdedHostSynctoClient(PLShipInfo instance, int salvageCompIndex, int salvageableComponentsCount)
+                {
+                    await Task.Yield();
+                    //need to wrap in try catch block if playership dies
+                    try
+                    {
+                        if (salvageCompIndex < 0)
+                        {
+                            for (int i = salvageCompIndex; i < 0; i++)
+                            {
+                                instance.photonView.RPC("SalvageNext", PhotonTargets.MasterClient, new object[0]);
+                                await Task.Delay(200);
+                            }
+                        }
+                        if (salvageCompIndex > salvageableComponentsCount)
+                        {
+                            for (int i = salvageCompIndex; i >= salvageableComponentsCount; i--)
+                            {
+                                instance.photonView.RPC("SalvagePrev", PhotonTargets.MasterClient, new object[0]);
+                                await Task.Delay(100);
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        return;
+                    }
+                    await Task.Delay(1000);
+                }
+                internal static void DeleteButtonOnUnload()
+                {
+                    storedCurrentShip = null;
+                    GameObject.Destroy(syncButton);
+                }
+                private static PLShipInfo storedCurrentShip = null;
+                private static GameObject syncButton = null;
+            }
+            [HarmonyPatch(typeof(PLShipInfo), "OnPhotonSerializeView")]
+            class ClientExtractSyncFix
+            {
+                private static float NextCheckTime = float.MinValue;
+                //Currently when you click the button to switch what component is being looked at on the extractor screen, for the next 2 seconds it becomes client sided with the host side extractor value not being synced
+                //What this transpiler does is always copu the host side value for the playerships extractor component index to a static value
+                //Which can then be read by other parts of the extractor fixes to keep track of if the host is synced or not
+                static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+                {
+                    List<CodeInstruction> instructionslist = instructions.ToList();
+                    CodeInstruction[] targetSequence = new CodeInstruction[]
+                    {
+                        //kept for clarity of what is being patched
+                        //new CodeInstruction(OpCodes.Ldarg_1, null),
+                        //new CodeInstruction(OpCodes.Callvirt, AccessTools.Method(typeof(PhotonStream), "RecieveNext")),
+                        //new CodeInstruction(OpCodes.Unbox_Any, null),
+                        new CodeInstruction(OpCodes.Stloc_S, null),//7
+                        new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Time), "get_time")),
+                        new CodeInstruction(OpCodes.Ldarg_0, null),
+                        new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(PLShipInfo), "LastLocalSalvageCompIDChangedTime")),
+                        new CodeInstruction(OpCodes.Sub, null),
+                        new CodeInstruction(OpCodes.Ldc_R4, 2f),
+                        new CodeInstruction(OpCodes.Ble_Un_S),
+                        new CodeInstruction(OpCodes.Ldarg_0, null),
+                        new CodeInstruction(OpCodes.Ldloc_S, null),
+                        new CodeInstruction(OpCodes.Stfld, AccessTools.Field(typeof(PLShipInfo), "SalvageComp_ID"))
+                    };
+                    CodeInstruction[] ReplacementSequence = new CodeInstruction[]
+                    {
+                        //new CodeInstruction(OpCodes.Stsfld, AccessTools.Field(typeof(HostToClientExtractSyncFix), "TempSalvageID"))
+                        new CodeInstruction(OpCodes.Ldarg_0, null),
+                        new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(ClientExtractSyncFix), "ReadSalvageData"))
+                    };
+                    return HarmonyHelpers.PatchBySequence(instructions, targetSequence, ReplacementSequence, PatchMode.REPLACE, CheckMode.NONNULL, false);
+                }
+                public static void ReadSalvageData(int inputID, PLShipInfo instance)
+                {
+                    if (instance.GetIsPlayerShip())
+                    {
+                        HostSalvageID = inputID;
+                    }
+                }
+                //This postfix reimplements the delayed syncing after pressing the button that changes the component being looked at on the extractor
+                static void Postfix(PLShipInfo __instance, ref PhotonStream stream, ref int ___SalvageComp_ID, List<PLShipComponent> ___m_CachedSalvageableComponents)
+                {
+                    //iswriting checks if the playership is owned by the player, it should always be owned by the host but good to check, also if it iswriting then it is syncing data to others so it does not need to to run the sync to host code
+                    //won't run if master client or if the ship isn't the playership
+                    if (stream.isWriting || PhotonNetwork.isMasterClient || !__instance.GetIsPlayerShip())
+                    {
+                        return;
+                    }
+                    if (Time.time - __instance.LastLocalSalvageCompIDChangedTime > 2f)
+                    {
+                        ___SalvageComp_ID = HostSalvageID;
+                    }
+                    return;
+                }
+                
+            }
+            [HarmonyPatch(typeof(PLShipInfo), "<CreateSalvageOpUIs>b__360_1")]
+            class ExtractScreenFixesGoRight
+            {
+                //Disables the go right button on the extractor screen 
+                static bool Prefix(PLShipInfo __instance, int ___SalvageComp_ID, List<PLShipComponent> ___m_CachedSalvageableComponents)
+                {
+                    if (!(MasterClientHasUpdatedMod || IsHostOnBoard()))
+                    {
+                        bool flag = ___SalvageComp_ID < (___m_CachedSalvageableComponents.Count - 1) && (AsyncNonHostSyncer == null || AsyncNonHostSyncer.IsCompleted);
+                        if (flag)
+                        {
+                            HostSalvageID++;
+                        }
+                        else
+                        {
+                            Messaging.Notification("Extractor cannot loop as host is not on board");
+                        }
+                        return flag;
+                    }
+                    return true;
+                }
+            }
+            [HarmonyPatch(typeof(PLShipInfo), "<CreateSalvageOpUIs>b__360_2")]
+            class ExtractScreenFixesGoLeft
+            {
+                static bool Prefix(PLShipInfo __instance, int ___SalvageComp_ID, List<PLShipComponent> ___m_CachedSalvageableComponents)
+                {
+                    if (!(MasterClientHasUpdatedMod || IsHostOnBoard()))
+                    {
+                        bool flag = ___SalvageComp_ID > 0 && (AsyncNonHostSyncer == null || AsyncNonHostSyncer.IsCompleted);
+                        if (flag)
+                        {
+                            HostSalvageID--;
+                        }
+                        else
+                        {
+                            Messaging.Notification("Extractor cannot loop as host is not on board");
+                        }
+                        return flag;
+                    }
+                    return true;
+                }
+            }
+            //Method to be run in an event to check host mod version of quality improver and set MasterClientHasUpdatedMod to true if they possess a newer version than the one prior to this release
+            //So that various extractor client side fixes can know if they need to run or not
+            internal static void ExtractorFixesHostVersionCheck(PhotonPlayer player)
+            {
+                if (PhotonNetwork.isMasterClient)
+                {
+                    MasterClientHasUpdatedMod = true;
+                    return;
+                }
+                if (player == PhotonNetwork.masterClient)
+                {
+                    MasterClientHasUpdatedMod = false;
+                    if (MPModCheckManager.Instance.GetNetworkedPeerModlistExists(player))
+                    {
+                        MPUserDataBlock playerModInfo = MPModCheckManager.Instance.GetNetworkedPeerMods(player);
+                        foreach (MPModDataBlock modDataBlock in playerModInfo.ModData)
+                        {
+                            if (modDataBlock.HarmonyIdentifier.Equals(Mod.Instance.HarmonyIdentifier()))
+                            {
+                                string[] version = modDataBlock.Version.Split('.');
+                                if (version.Length > 2)
+                                {
+                                    //2.3.6 is the version prior to when this is was originally made
+                                    if (Int32.Parse(version[0]) > 2)
+                                    {
+                                        MasterClientHasUpdatedMod = true;
+                                    }
+                                    if (Int32.Parse(version[1]) > 3)
+                                    {
+                                        MasterClientHasUpdatedMod = true;
+                                    }
+                                    if (Int32.Parse(version[2]) > 6)
+                                    {
+                                        MasterClientHasUpdatedMod = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            //Method to check if host is on board for client side extractor scrolling fixes
+            internal static bool IsHostOnBoard()
+            {
+                PLPlayer host = null;
+                foreach(PLPlayer player in PLServer.Instance.AllPlayers)
+                {
+                    if (player.PhotonPlayer == PhotonNetwork.masterClient)
+                    {
+                        host = player;
+                        break;
+                    }
+                }
+                return PLEncounterManager.Instance.PlayerShip != null && host != null && PLEncounterManager.Instance.PlayerShip.MyTLI == host.MyCurrentTLI;
+            }
+        }
     }
 }
+

--- a/QualityImprover/Patches.cs
+++ b/QualityImprover/Patches.cs
@@ -1068,6 +1068,8 @@ namespace QualityImprover
                 }
             }
         }
+        
+
         [HarmonyPatch(typeof(PLShipControl), "FixedUpdate")]
         class DirectManeuverUpDownReflectionFix
         {
@@ -1085,7 +1087,6 @@ namespace QualityImprover
                         if (count == 18)
                         {
                             localVariable = instructionslist[i].operand;
-                            UnityEngine.Debug.Log($"{localVariable.ToString()}");
                         }
                     }
                     if (localVariable != null)

--- a/QualityImprover/QualityImprover.csproj
+++ b/QualityImprover/QualityImprover.csproj
@@ -4,6 +4,14 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Lib.Harmony" Version="2.2.2">
       <IncludeAssets>compile</IncludeAssets>
@@ -28,6 +36,7 @@
     </Reference>
     <Reference Include="PulsarModLoader">
       <HintPath>..\Packages\PulsarModLoader.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\PULSARLostColony\PULSAR_LostColony_Data\Managed\UnityEngine.dll</HintPath>


### PR DESCRIPTION
Caveat to extractor fix:
When host has it it will always work normally,
If the host doesn't have it, while the host player is not on board you will not just be able to click one direction arrow endlessly and have it loop forever. That is disabled due to desync.
If the host gets desynced while not being on board from other unmodded players using the screen a button will pop up for the modded player to fix the desync to keep the extractor working while the host isn't on board.