### PR TITLE
2.3.8

### DIFF
--- a/QualityImprover/Mod.cs
+++ b/QualityImprover/Mod.cs
@@ -11,7 +11,7 @@ namespace QualityImprover
             Events.Instance.ClientModlistRecievedEvent += QualityImprover.Patches.ExtractorFixes.ExtractorFixesHostVersionCheck;
         }
         internal static Mod Instance;
-        public override string Version => "2.3.7";
+        public override string Version => "2.3.8";
 
         public override string Author => "pokegustavo, OnHyex";
 

--- a/QualityImprover/QualityImprover.csproj
+++ b/QualityImprover/QualityImprover.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Added two new patches:
1. Fixed the ai priority override about hull breaches now having an editable data field to change the number of hull breaches to be checked
2.Fixed the main turret missile launcher code to listen for the missile fire button instead of the right click keybind, the missile fire  is only checked once for both firing missiles and for the double click fire pulse laser but the dedicated pulse laser button (by default q) still exists.